### PR TITLE
reset iterator on _iter_init

### DIFF
--- a/src/Collection.gd
+++ b/src/Collection.gd
@@ -268,6 +268,7 @@ func size():  # int
 
 # @override  _iter_init(?)
 func _iter_init(arg):  # bool
+	self._iterationCurrent = 0
 	return self._iterationCurrent < self.length
 
 


### PR DESCRIPTION
Custom iterators are required to reset the state in _iter_init, This fixes an issue when iterating over the same Collection mutliple times. Described in the documentation [here](https://docs.godotengine.org/en/stable/getting_started/scripting/gdscript/gdscript_advanced.html#custom-iterators).

This also fixes [Issue 15 on Godot Console](https://github.com/quentincaffeino/godot-console/issues/15)
